### PR TITLE
Improve color recognition of card backgrounds

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -70,9 +70,8 @@ function fillHand(outputElt, deck) {
                 }
             }
             if (!exists) {
-                cardElt = $("<div>", {"class": "card card-" + card.color + " entering"});
+                cardElt = $("<div>", {"class": `card bg-${card.plateBackground} entering`});
                 cardElt.append($(`<span class="card-name">${card.name}</span>`));
-                // cardElt.text(card.name);
                 var costElt = $("<span>", {"class": "mana"});
                 costElt.html(toCost(card.cost && ("" + card.cost), card.altCost));
                 cardElt.prepend(costElt);

--- a/css/cards.css
+++ b/css/cards.css
@@ -1,0 +1,31 @@
+.bg-land {
+  background-color: #d7d1cf ! important;
+}
+
+.bg-artifact {
+  background-color: #dee6e9 ! important;
+}
+
+.bg-white {
+  background-color: #f5f6f1 ! important;
+}
+
+.bg-blue {
+  background-color: #c4dfed ! important;
+}
+
+.bg-black {
+  background-color: #C8C2C2 ! important;
+}
+
+.bg-red {
+  background-color: #f5d3c3 ! important;
+}
+
+.bg-green {
+  background-color: #c2cebf ! important;
+}
+
+.bg-multicolor {
+  background-color: #ecd997 ! important;
+}

--- a/decklistbot/deckimport.js
+++ b/decklistbot/deckimport.js
@@ -29,14 +29,6 @@ function doRequest(names, counts, deck, output, sideboard, callback, page, reque
             for (i = 0; i < data.cards.length; i++) {
                 var card = data.cards[i];
                 if (counts.hasOwnProperty(card.name.toLowerCase())) {
-                    var color;
-                    if (!card.colorIdentity) {
-                        color = "C";
-                    } else if (card.colorIdentity.length == 1) {
-                        color = card.colorIdentity[0];
-                    } else {
-                        color = "M";
-                    }
                     var name = card.name;
                     var cost = card.manaCost || "";
                     var altCost = "";
@@ -50,7 +42,7 @@ function doRequest(names, counts, deck, output, sideboard, callback, page, reque
                     var cardOut = {
                         name: name,
                         type: card.type,
-                        color: color,
+                        plateBackground: getNameplateBackgroundColor(card),
                         cost: cost,
                         altCost: altCost,
                         count: counts[card.name.toLowerCase()],
@@ -137,6 +129,51 @@ if (typeof window !== "undefined") {
             }, requestor);
         });
     });
+}
+
+function getNameplateBackgroundColor(card) {
+    if (card.type && card.type.includes('Land')) {
+        if (card.supertypes && card.supertypes.includes('Basic')) {
+            // Basic land
+            return basicLandNameToBackgroundColorType(card.name);
+        } else {
+            // Nonbasic land
+            return 'land';
+        }
+    } else if (card.colors && card.colors.length > 0) {
+        if (card.colors.length >= 2) {
+            // Multicolor
+            return 'multicolor';
+        } else {
+            // Single color
+            return card.colors[0].toLowerCase();
+        }
+    } else {
+        if (card.types && card.types.includes('Artifact')) {
+            // Artifact
+            return 'artifact';
+        } else {
+            // Colorless
+            return 'colorless';
+        }
+    }
+}
+
+function basicLandNameToBackgroundColorType(basicLandName) {
+    switch (basicLandName) {
+        case 'Plains':
+            return 'white';
+        case 'Island':
+            return 'blue';
+        case 'Swamp':
+            return 'black';
+        case 'Mountain':
+            return 'red';
+        case 'Forest':
+            return 'green';
+        default:
+            return 'unknown';
+    }
 }
 
 (function (exports) {

--- a/overlay-ned1.html
+++ b/overlay-ned1.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Cantata+One" rel="stylesheet">
     <link href="css/mana.css" rel="stylesheet" type="text/css"/>
+    <link href="css/cards.css" rel="stylesheet" type="text/css"/>
     <link href="https://bowercdn.net/c/jqueryemoji-1.0.1/css/style.css" rel="stylesheet" type="text/css"/>
     <script src="https://code.jquery.com/jquery-3.1.0.min.js"
             integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s=" crossorigin="anonymous"></script>

--- a/spotter.css
+++ b/spotter.css
@@ -56,34 +56,6 @@
   border-radius: 10px;
 }
 
-.cardControl.C {
-  background-color: #f2edeb;
-}
-
-.cardControl.W {
-  background-color: #ffffff;
-}
-
-.cardControl.U {
-  background-color: #e6eef2;
-}
-
-.cardControl.B {
-  background-color: #d9d2d2;
-}
-
-.cardControl.R {
-  background-color: #f5e7e1;
-}
-
-.cardControl.G {
-  background-color: #e5f2e1;
-}
-
-.cardControl.M {
-  background-color: #ebe2c7;
-}
-
 .cardControl.inHand {
   font-weight: bold;
 }

--- a/spotter.html
+++ b/spotter.html
@@ -3,6 +3,7 @@
     <title>spotter dashboard</title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="spotter.css">
+    <link rel="stylesheet" type="text/css" href="css/cards.css" />
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Condensed" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Metal+Mania" rel="stylesheet">
     <link href="css/mana.css" rel="stylesheet" type="text/css"/>

--- a/spotter.js
+++ b/spotter.js
@@ -1,5 +1,5 @@
 var spotterControlTemplate = _.template(`
-<div class="cardControl <% if (count > 0) { %>inHand<% } %> <% if (sideboard) { %>sideboard<% } %> <%= color %>" 
+<div class="cardControl <% if (count > 0) { %>inHand<% } %> <% if (sideboard) { %>sideboard<% } %> bg-<%= bgColor %>" 
         id="card_<%= player %>_<%= index %>">
     <div class="minus button">-</div>
     <div class="name"><%= name %></div>
@@ -33,7 +33,7 @@ function createSpotterControl(card, player) {
             {
                 name: card.name,
                 count: card.inhand,
-                color: card.color,
+                bgColor: card.plateBackground,
                 sideboard: card.sideboard,
                 player: player,
                 index: card.index

--- a/style-ned1.css
+++ b/style-ned1.css
@@ -251,9 +251,6 @@ body {
   width: 235px;
   height: 29px;
   box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   transition: transform 400ms cubic-bezier(0.4, 0.0, 0.2, 1);
 }
 
@@ -288,36 +285,11 @@ body {
   transform: translateX(100%);
 }
 
-.card-C {
-  background-color: #d7d1cf ! important;
-}
-
-.card-W {
-  background-color: #f5f6f1 ! important;
-}
-
-.card-U {
-  background-color: #c4dfed ! important;
-}
-
-.card-B {
-  background-color: #c0b9b9 ! important;
-}
-
-.card-R {
-  background-color: #f5d3c3 ! important;
-}
-
-.card-G {
-  background-color: #c2cebf ! important;
-}
-
-.card-M {
-  background-color: #ecd997 ! important;
-}
-
 .card-name {
   flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mana {


### PR DESCRIPTION
Move away from color identity (which is easily fooled) to
something more advanced. Still doesn't work for special cases
like lands which produce iridescent mana (should get gold
backgrounds) or split cards (currently they just take the color
of the first half).